### PR TITLE
add:新規登録画面の項目追加

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -32,12 +32,15 @@ class RegisteredUserController extends Controller
     {
         $request->validate([
             'name' => 'required|string|max:255',
+            'login_id' => 'required|string|max:255|unique:users',
             'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'birthday' => ['nullable', 'date'],
         ]);
 
         $user = User::create([
             'name' => $request->name,
+            'login_id' => $request->login_id,
             'email' => $request->email,
             'password' => Hash::make($request->password),
         ]);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,8 +19,10 @@ class User extends Authenticatable
      */
     protected $fillable = [
         'name',
+        'login_id',
         'email',
         'password',
+        'birthday',
     ];
 
     /**

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->date('birthday')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -13,7 +13,6 @@ export default function Login({ status, canResetPassword }) {
         remember: false,
     });
 
-    // あ
     const submit = (e) => {
         e.preventDefault();
 

--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -8,9 +8,11 @@ import { Head, Link, useForm } from '@inertiajs/react';
 export default function Register() {
     const { data, setData, post, processing, errors, reset } = useForm({
         name: '',
+        login_id: '',
         email: '',
         password: '',
         password_confirmation: '',
+        birthday: '',
     });
 
     const submit = (e) => {
@@ -41,6 +43,22 @@ export default function Register() {
                     />
 
                     <InputError message={errors.name} className="mt-2" />
+                </div>
+
+                <div className="mt-4">
+                    <InputLabel htmlFor="login_id" value="ログインID" />
+
+                    <TextInput
+                        id="login_id"
+                        name="login_id"
+                        value={data.email}
+                        className="mt-1 block w-full"
+                        autoComplete="login_id"
+                        onChange={(e) => setData('login_id', e.target.value)}
+                        required
+                    />
+
+                    <InputError message={errors.login_id} className="mt-2" />
                 </div>
 
                 <div className="mt-4">
@@ -102,16 +120,31 @@ export default function Register() {
                     />
                 </div>
 
+                <div className="mt-4">
+                    <InputLabel htmlFor="birthday" value="生年月日" />
+
+                    <TextInput
+                        id="birthday"
+                        type="date"
+                        name="birthday"
+                        value={data.birthday}
+                        className="mt-1 block w-full"
+                        onChange={(e) => setData('birthday', e.target.value)}
+                    />
+
+                    <InputError message={errors.birthday} className="mt-2" />
+                </div>
+
                 <div className="mt-4 flex items-center justify-end">
                     <Link
                         href={route('login')}
                         className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                     >
-                        既に登録済みですか？
+                        すでにアカウントをお持ちですか？
                     </Link>
 
                     <PrimaryButton className="ms-4" disabled={processing}>
-                        新規登録
+                        登録
                     </PrimaryButton>
                 </div>
             </form>


### PR DESCRIPTION
## 変更点
「新規登録に login_id、birthday 項目を追加」
このプルリクエストでは、ユーザー登録時に「ログインID(login_id)、生年月日 (birthday)」項目を追加しています。

バックエンドの変更: users テーブルに birthday カラムを追加するマイグレーションを作成しました。また、RegisteredUserController と User モデルを修正して新しい項目を取り扱うようにしています。
フロントエンドの変更: 登録フォームに「ログインID(login_id)　生年月日 (birthday)」の入力欄を追加しました。