### PR TITLE
プロフィール画面の項目追加

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -21,6 +21,7 @@ class ProfileController extends Controller
         return Inertia::render('Profile/Edit', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
+            'user' => $request->user()->only('login_id', 'nickname', 'email', 'birthday'), // 必要なフィールドを取得
         ]);
     }
 
@@ -29,15 +30,31 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        // $request->user()->fill($request->validated());
 
-        if ($request->user()->isDirty('email')) {
-            $request->user()->email_verified_at = null;
+        // if ($request->user()->isDirty('email')) {
+        //     $request->user()->email_verified_at = null;
+        // }
+
+        // $request->user()->save();
+
+        // return Redirect::route('profile.edit');
+
+        $user = $request->user();
+
+        // フォームのバリデーション済みデータを反映
+        $user->fill($request->validated());
+
+        // メールアドレスが変更された場合、認証状態をリセット
+        if ($user->isDirty('email')) {
+            $user->email_verified_at = null;
         }
 
-        $request->user()->save();
+        // ユーザー情報の保存
+        $user->save();
 
-        return Redirect::route('profile.edit');
+        // 成功メッセージをセッションに追加
+        return Redirect::route('profile.edit')->with('status', 'プロフィールが更新されました。');
     }
 
     /**
@@ -58,6 +75,7 @@ class ProfileController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        return Redirect::to('/');
+        // return Redirect::to('/');
+        return Redirect::to('/')->with('status', 'アカウントが削除されました。');
     }
 }

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -16,7 +16,13 @@ class ProfileUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'nickname' => ['required', 'string', 'max:255'],
+            'login_id' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique(User::class)->ignore($this->user()->id), // ログインIDの一意性をチェック
+            ],
             'email' => [
                 'required',
                 'string',
@@ -25,6 +31,7 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'birthday' => ['nullable', 'date'],
         ];
     }
 }

--- a/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
+++ b/resources/js/Pages/Profile/Partials/DeleteUserForm.jsx
@@ -49,32 +49,26 @@ export default function DeleteUserForm({ className = '' }) {
         <section className={`space-y-6 ${className}`}>
             <header>
                 <h2 className="text-lg font-medium text-gray-900">
-                    Delete Account
+                    アカウントを削除
                 </h2>
 
                 <p className="mt-1 text-sm text-gray-600">
-                    Once your account is deleted, all of its resources and data
-                    will be permanently deleted. Before deleting your account,
-                    please download any data or information that you wish to
-                    retain.
+                アカウントを削除すると、その全てのデータが永久に削除されます。アカウントを削除する前に、保存したいデータをダウンロードしてください。
                 </p>
             </header>
 
             <DangerButton onClick={confirmUserDeletion}>
-                Delete Account
+                アカウントを削除
             </DangerButton>
 
             <Modal show={confirmingUserDeletion} onClose={closeModal}>
                 <form onSubmit={deleteUser} className="p-6">
                     <h2 className="text-lg font-medium text-gray-900">
-                        Are you sure you want to delete your account?
+                        本当に削除しますか？
                     </h2>
 
                     <p className="mt-1 text-sm text-gray-600">
-                        Once your account is deleted, all of its resources and
-                        data will be permanently deleted. Please enter your
-                        password to confirm you would like to permanently delete
-                        your account.
+                    アカウントを削除すると、その全てのデータが永久に削除されます。アカウントを削除するには、パスワードを入力してください。
                     </p>
 
                     <div className="mt-6">
@@ -95,7 +89,7 @@ export default function DeleteUserForm({ className = '' }) {
                             }
                             className="mt-1 block w-3/4"
                             isFocused
-                            placeholder="Password"
+                            placeholder="パスワード"
                         />
 
                         <InputError
@@ -106,11 +100,11 @@ export default function DeleteUserForm({ className = '' }) {
 
                     <div className="mt-6 flex justify-end">
                         <SecondaryButton onClick={closeModal}>
-                            Cancel
+                            キャンセル
                         </SecondaryButton>
 
                         <DangerButton className="ms-3" disabled={processing}>
-                            Delete Account
+                            アカウントを削除
                         </DangerButton>
                     </div>
                 </form>

--- a/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdatePasswordForm.jsx
@@ -48,12 +48,11 @@ export default function UpdatePasswordForm({ className = '' }) {
         <section className={className}>
             <header>
                 <h2 className="text-lg font-medium text-gray-900">
-                    Update Password
+                    パスワードの更新
                 </h2>
 
                 <p className="mt-1 text-sm text-gray-600">
-                    Ensure your account is using a long, random password to stay
-                    secure.
+                アカウントを安全に保つために、長くランダムなパスワードを使用してください。
                 </p>
             </header>
 
@@ -61,7 +60,7 @@ export default function UpdatePasswordForm({ className = '' }) {
                 <div>
                     <InputLabel
                         htmlFor="current_password"
-                        value="Current Password"
+                        value="現在のパスワード"
                     />
 
                     <TextInput
@@ -83,7 +82,7 @@ export default function UpdatePasswordForm({ className = '' }) {
                 </div>
 
                 <div>
-                    <InputLabel htmlFor="password" value="New Password" />
+                    <InputLabel htmlFor="password" value="新しいパスワード" />
 
                     <TextInput
                         id="password"
@@ -101,7 +100,7 @@ export default function UpdatePasswordForm({ className = '' }) {
                 <div>
                     <InputLabel
                         htmlFor="password_confirmation"
-                        value="Confirm Password"
+                        value="パスワードの確認"
                     />
 
                     <TextInput
@@ -122,7 +121,7 @@ export default function UpdatePasswordForm({ className = '' }) {
                 </div>
 
                 <div className="flex items-center gap-4">
-                    <PrimaryButton disabled={processing}>Save</PrimaryButton>
+                    <PrimaryButton disabled={processing}>保存</PrimaryButton>
 
                     <Transition
                         show={recentlySuccessful}
@@ -132,7 +131,7 @@ export default function UpdatePasswordForm({ className = '' }) {
                         leaveTo="opacity-0"
                     >
                         <p className="text-sm text-gray-600">
-                            Saved.
+                            保存しました。
                         </p>
                     </Transition>
                 </div>

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -14,8 +14,10 @@ export default function UpdateProfileInformation({
 
     const { data, setData, patch, errors, processing, recentlySuccessful } =
         useForm({
-            name: user.name,
+            nickname: user.nickname,
             email: user.email,
+            birthday: user.birthday,
+            login_id: user.login_id, // ログインIDを初期値として設定
         });
 
     const submit = (e) => {
@@ -28,33 +30,48 @@ export default function UpdateProfileInformation({
         <section className={className}>
             <header>
                 <h2 className="text-lg font-medium text-gray-900">
-                    Profile Information
+                    プロフィール情報
                 </h2>
 
                 <p className="mt-1 text-sm text-gray-600">
-                    Update your account's profile information and email address.
+                アカウントのプロフィール情報、メールアドレス、ユーザID、生年月日を更新します。
                 </p>
             </header>
 
             <form onSubmit={submit} className="mt-6 space-y-6">
                 <div>
-                    <InputLabel htmlFor="name" value="Name" />
+                    <InputLabel htmlFor="login_id" value="ユーザID" />
 
                     <TextInput
-                        id="name"
+                        id="login_id"
+                        type="text"
                         className="mt-1 block w-full"
-                        value={data.name}
-                        onChange={(e) => setData('name', e.target.value)}
+                        value={data.login_id}
+                        onChange={(e) => setData('login_id', e.target.value)}
                         required
-                        isFocused
-                        autoComplete="name"
                     />
 
-                    <InputError className="mt-2" message={errors.name} />
+                    <InputError className="mt-2" message={errors.login_id} />
                 </div>
 
                 <div>
-                    <InputLabel htmlFor="email" value="Email" />
+                <InputLabel htmlFor="nickname" value="ニックネーム" />
+
+                    <TextInput
+                        id="nickname"
+                        className="mt-1 block w-full"
+                        value={data.nickname}
+                        onChange={(e) => setData('nickname', e.target.value)}
+                        required
+                        isFocused
+                        autoComplete="nickname"
+                    />
+
+                    <InputError className="mt-2" message={errors.nickname} />
+                </div>
+
+                <div>
+                    <InputLabel htmlFor="email" value="メールアドレス" />
 
                     <TextInput
                         id="email"
@@ -69,31 +86,45 @@ export default function UpdateProfileInformation({
                     <InputError className="mt-2" message={errors.email} />
                 </div>
 
+                <div>
+                    <InputLabel htmlFor="birthday" value="生年月日" />
+
+                    <TextInput
+                        id="birthday"
+                        type="date"
+                        className="mt-1 block w-full"
+                        value={data.birthday}
+                        onChange={(e) => setData('birthday', e.target.value)}
+                        autoComplete="birthday"
+                    />
+
+                    <InputError className="mt-2" message={errors.birthday} />
+                </div>
+
                 {mustVerifyEmail && user.email_verified_at === null && (
                     <div>
                         <p className="mt-2 text-sm text-gray-800">
-                            Your email address is unverified.
+                            メールアドレスが確認されていません。
                             <Link
                                 href={route('verification.send')}
                                 method="post"
                                 as="button"
                                 className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                             >
-                                Click here to re-send the verification email.
+                                メールの再送信はこちらをクリック
                             </Link>
                         </p>
 
                         {status === 'verification-link-sent' && (
                             <div className="mt-2 text-sm font-medium text-green-600">
-                                A new verification link has been sent to your
-                                email address.
+                                新しい確認リンクがメールアドレスに送信されました。
                             </div>
                         )}
                     </div>
                 )}
 
                 <div className="flex items-center gap-4">
-                    <PrimaryButton disabled={processing}>Save</PrimaryButton>
+                    <PrimaryButton disabled={processing}>保存</PrimaryButton>
 
                     <Transition
                         show={recentlySuccessful}
@@ -103,7 +134,7 @@ export default function UpdateProfileInformation({
                         leaveTo="opacity-0"
                     >
                         <p className="text-sm text-gray-600">
-                            Saved.
+                            保存されました。
                         </p>
                     </Transition>
                 </div>


### PR DESCRIPTION
## 概要
プロフィール更新機能に login_id（ユーザID）と生年月日の編集機能を追加し、
成功メッセージの表示とセキュリティ強化を行いました。

## 変更点
ログインID編集: プロフィールフォームに login_id を追加し、ユーザーがログインIDを編集できるようにしました。
成功メッセージ追加: プロフィール更新やアカウント削除後に成功メッセージを表示。

## 変更内容
ProfileController: login_id を取得・更新し、必要に応じて email_verified_at をリセット。削除時にセッション無効化。
フロントエンド: login_idと生年月日フィールドを追加し、保存時にメッセージを表示。

## 動作確認
login_id 編集・保存と成功メッセージの表示確認。
アカウント削除時の成功メッセージ確認。