### PR TITLE
add:パスワード・ユーザID確認メールを作成

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -47,5 +47,6 @@ class PasswordResetLinkController extends Controller
         throw ValidationException::withMessages([
             'email' => [trans($status)],
         ]);
+
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Notifications\CustomResetPasswordNotification;
 
 class User extends Authenticatable
 {
@@ -47,5 +48,13 @@ class User extends Authenticatable
             'password' => 'hashed',
             'birthday' => 'date',
         ];
+    }
+
+    /**
+     * パスワードリセット通知の送信メソッドをオーバーライド
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new CustomResetPasswordNotification($token));
     }
 }

--- a/app/Notifications/CustomResetPasswordNotification.php
+++ b/app/Notifications/CustomResetPasswordNotification.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class CustomResetPasswordNotification extends ResetPassword
+{
+    /**
+     * パスワードリセット通知メールの内容を定義
+     *
+     * @param mixed $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('パスワードリセットのお知らせ')
+            ->greeting("こんにちは、{$notifiable->nickname} さん！")
+            ->line("あなたのユーザIDは {$notifiable->login_id} です。")
+            ->line('以下のボタンをクリックして、パスワードリセット手続きを完了してください。')
+            ->action('パスワードをリセットする', url(route('password.reset', $this->token, false)))
+            ->line('このメールは ' . $notifiable->email . ' 宛に送信されています。')
+            ->line('もしこのメールに心当たりがない場合は、操作は不要です。');
+    }
+}

--- a/resources/js/Pages/Auth/ForgotPassword.jsx
+++ b/resources/js/Pages/Auth/ForgotPassword.jsx
@@ -17,12 +17,11 @@ export default function ForgotPassword({ status }) {
 
     return (
         <GuestLayout>
-            <Head title="パスワードをお忘れですか？" />
+            <Head title="ユーザID・パスワード再発行" />
 
             <div className="mb-4 text-sm text-gray-600">
-                パスワードを忘れましたか？問題ありません。
-                メールアドレスを入力していただければ、
-                パスワードリセット用のリンクを送信いたします。
+                登録いただいたメールアドレスを入力していただければ、
+                ユーザIDとパスワードリセット用のリンクを送信いたします。
             </div>
 
             {status && (
@@ -46,7 +45,7 @@ export default function ForgotPassword({ status }) {
 
                 <div className="mt-4 flex items-center justify-end">
                     <PrimaryButton className="ms-4" disabled={processing}>
-                        パスワードリセットリンクを送信
+                        送信
                     </PrimaryButton>
                 </div>
             </form>

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -86,7 +86,7 @@ export default function Login({ status, canResetPassword }) {
                             href={route('password.request')}
                             className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                         >
-                            パスワードをお忘れですか？
+                            ユーザID・パスワードを忘れた方はこちら
                         </Link>
                     )}
 


### PR DESCRIPTION
## 概要
メール認証の文章変更。
ログイン画面をユーザID・パスワードを忘れた方はこちらというリンクを追加

## 変更点
1.カスタム通知クラスの作成
2.カスタム通知クラスの編集
3.Userモデルでカスタム通知を使うように設定

## 動作確認
1.カスタム通知クラスの作成
php artisan make:notification CustomResetPasswordNotification

2. カスタム通知クラスの編集
生成された CustomResetPasswordNotification クラスを開き、
メールの内容にlogin_idとパスワードリセットリンクを含めるようにします。

3. Userモデルでカスタム通知を使うように設定
次に、UserモデルでsendPasswordResetNotificationメソッドをオーバーライドし、カスタム通知CustomResetPasswordNotificationを使用するように設定します。

## その他
- 後回しにしている課題
二段階認証