### PR TITLE
change:プロフィールのファイル名変更とバリデーションチェックのコード改良

### DIFF
--- a/app/Http/Requests/Auth/ForgotPasswordRequest.php
+++ b/app/Http/Requests/Auth/ForgotPasswordRequest.php
@@ -40,25 +40,16 @@ class ForgotPasswordRequest extends FormRequest
 
     protected function failedValidation(Validator $validator)
     {
-        // バリデーションエラーメッセージを取得
         $validationErrors = $validator->errors()->getMessages();
         $formattedErrors = [];
     
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        // JSONリクエストの場合はエラーレスポンスを返す
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-    
-        // HTMLリクエストの場合はリダイレクトし、エラーメッセージを表示
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -41,16 +41,16 @@ class LoginRequest extends FormRequest
     {
         $validationErrors = $validator->errors()->getMessages();
         $formattedErrors = [];
-
+    
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
-
+    
         throw new HttpResponseException(
-            response()->json(['errors' => $formattedErrors], 422)
+            back()->withErrors($formattedErrors)->withInput()
         );
     }
 }

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -115,14 +115,8 @@ class RegisterRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
-        }
-    
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
         }
     
         throw new HttpResponseException(

--- a/app/Http/Requests/Auth/ResetPasswordRequest.php
+++ b/app/Http/Requests/Auth/ResetPasswordRequest.php
@@ -57,14 +57,8 @@ class ResetPasswordRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
-        }
-    
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
         }
     
         throw new HttpResponseException(

--- a/app/Http/Requests/Calendar/EventRequest.php
+++ b/app/Http/Requests/Calendar/EventRequest.php
@@ -111,16 +111,10 @@ class EventRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Calendar/MonthlyEventRequest.php
+++ b/app/Http/Requests/Calendar/MonthlyEventRequest.php
@@ -147,20 +147,14 @@ class MonthlyEventRequest extends FormRequest
     {
         $validationErrors = $validator->errors()->getMessages();
         $formattedErrors = [];
-
+    
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
-
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
+    
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Calendar/TagRequest.php
+++ b/app/Http/Requests/Calendar/TagRequest.php
@@ -54,16 +54,10 @@ class TagRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Calendar/WeekdayEventRequest.php
+++ b/app/Http/Requests/Calendar/WeekdayEventRequest.php
@@ -115,16 +115,10 @@ class WeekdayEventRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Calendar/WeekendEventRequest.php
+++ b/app/Http/Requests/Calendar/WeekendEventRequest.php
@@ -115,16 +115,10 @@ class WeekendEventRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Calendar/WeeklyEventRequest.php
+++ b/app/Http/Requests/Calendar/WeeklyEventRequest.php
@@ -117,16 +117,10 @@ class WeeklyEventRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Calendar/YearlyEventRequest.php
+++ b/app/Http/Requests/Calendar/YearlyEventRequest.php
@@ -143,20 +143,14 @@ class YearlyEventRequest extends FormRequest
     {
         $validationErrors = $validator->errors()->getMessages();
         $formattedErrors = [];
-
+    
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
-
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
+    
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Profile/DeleteProfileRequest.php
+++ b/app/Http/Requests/Profile/DeleteProfileRequest.php
@@ -43,16 +43,16 @@ class DeleteProfileRequest extends FormRequest
     {
         $validationErrors = $validator->errors()->getMessages();
         $formattedErrors = [];
-
+    
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
-
+    
         throw new HttpResponseException(
-            response()->json(['errors' => $formattedErrors], 422)
+            back()->withErrors($formattedErrors)->withInput()
         );
     }
 }

--- a/app/Http/Requests/Profile/PasswordUpdateRequest.php
+++ b/app/Http/Requests/Profile/PasswordUpdateRequest.php
@@ -68,16 +68,10 @@ class PasswordUpdateRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/app/Http/Requests/Profile/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Profile/ProfileUpdateRequest.php
@@ -115,16 +115,10 @@ class ProfileUpdateRequest extends FormRequest
         foreach ($validationErrors as $field => $messages) {
             $formattedErrors[$field] = array_map(function ($message) {
                 $decodedMessage = json_decode($message, true);
-                return $decodedMessage['description'] ?? $message;
+                return $decodedMessage['description'];
             }, $messages);
         }
     
-        if ($this->expectsJson()) {
-            throw new HttpResponseException(
-                response()->json(['errors' => $formattedErrors], 422)
-            );
-        }
-
         throw new HttpResponseException(
             back()->withErrors($formattedErrors)->withInput()
         );

--- a/resources/js/Pages/Profile/Profile.jsx
+++ b/resources/js/Pages/Profile/Profile.jsx
@@ -6,7 +6,7 @@ import DeleteProfileForm from "./Partials/Forms/DeleteProfileForm";
 import UpdatePasswordForm from "./Partials/Forms/UpdatePasswordForm";
 import UpdateProfileForm from "./Partials/Forms/UpdateProfileForm";
 
-export default function Edit() {
+export default function Profile() {
     const { auth } = usePage().props;
     const [profile, setProfile] = useState(auth.user);
     const [mustVerifyEmail, setMustVerifyEmail] = useState(false);
@@ -24,7 +24,7 @@ export default function Edit() {
     const handleUpdateProfile = (nickname, email, birthday, login_id) => {
         const token = localStorage.getItem("token");
         if (!token) {
-            setError("No authentication token found");
+            setError("認証トークンが見つかりません");
             return;
         }
 
@@ -41,10 +41,10 @@ export default function Edit() {
             )
             .then((response) => {
                 setProfile(response.data.user);
-                setStatus("Profile updated successfully");
+                setStatus("プロフィールが正常に更新されました");
             })
             .catch((error) => {
-                setError("There was an error updating the profile!");
+                setError("プロフィールの更新中にエラーが発生しました！");
                 console.error(error);
             });
     };
@@ -52,7 +52,7 @@ export default function Edit() {
     const handleUpdatePassword = (currentPassword, newPassword) => {
         const token = localStorage.getItem("token");
         if (!token) {
-            setError("No authentication token found");
+            setError("認証トークンが見つかりません");
             return;
         }
 
@@ -68,10 +68,10 @@ export default function Edit() {
                 }
             )
             .then((response) => {
-                setStatus("Password updated successfully");
+                setStatus("パスワードが正常に更新されました");
             })
             .catch((error) => {
-                setError("There was an error updating the password!");
+                setError("パスワードの更新中にエラーが発生しました！");
                 console.error(error);
             });
     };
@@ -79,7 +79,7 @@ export default function Edit() {
     const handleDeleteAccount = (password) => {
         const token = localStorage.getItem("token");
         if (!token) {
-            setError("No authentication token found");
+            setError("認証トークンが見つかりません");
             return;
         }
 
@@ -92,10 +92,10 @@ export default function Edit() {
                 },
             })
             .then((response) => {
-                setStatus("Account deleted successfully");
+                setStatus("アカウントが正常に削除されました");
             })
             .catch((error) => {
-                setError("There was an error deleting the account!");
+                setError("アカウントの削除中にエラーが発生しました！");
                 console.error(error);
             });
     };

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,17 +8,7 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\PasswordResetController;
 use App\Http\Controllers\Profile\ProfileController;
 
-//ホームページルート
-Route::get('/', function () {
-    return Inertia::render('Auth/AuthForm');
-})->name('auth.toggle');
-
-//カレンダールート（認証済みユーザーのみ）
-Route::middleware(['auth', 'verified'])->group(function () {
-    Route::get('/calendar', fn() => Inertia::render('Calendar'))->name('calendar');
-});
-
-//誰でもアクセス可能なルート（ログイン・登録・パスワードリセット）
+// 誰でもアクセス可能なルート（ログイン・登録・パスワードリセット）
 Route::get('login', [LoginController::class, 'create'])->name('login');
 Route::post('login', [LoginController::class, 'login']);
 
@@ -31,19 +21,23 @@ Route::post('forgot-password', [PasswordResetController::class, 'sendPasswordRes
 Route::get('reset-password/{token}', fn($token) => Inertia::render('Auth/ResetPasswordForm', ['token' => $token]))->name('password.reset');
 Route::post('reset-password', [PasswordResetController::class, 'resetPassword'])->name('password.update');
 
-//認証済みユーザー専用ルート（プロフィール・ログアウト）
+// 認証済みユーザー専用ルート（プロフィール・ログアウト）
 Route::middleware('auth')->prefix('user')->group(function () {
     Route::post('logout', [LogoutController::class, 'logout'])->name('logout');
 
     Route::controller(ProfileController::class)->prefix('profile')->group(function () {
-        Route::get('/edit', 'edit')->name('profile.edit');
+        Route::get('/edit', fn() => Inertia::render('Profile/Profile'))->name('profile.edit'); // 修正
         Route::put('/', 'update')->name('profile.update');
         Route::put('/password', 'password')->name('profile.password');
         Route::delete('/', 'destroy')->name('profile.destroy');
     });
 
+    // カレンダールート（認証済みユーザーのみ）
+    Route::middleware(['auth', 'verified'])->group(function () {
+        Route::get('/calendar', fn() => Inertia::render('Calendar/Calendar'))->name('calendar');
+    });
+
     // Web UI 向けルート
-    Route::get('calendar', fn() => Inertia::render('Calendar/Calendar'))->name('calendar');
     Route::get('weather', fn() => Inertia::render('Weather/Weather'))->name('weather');
     Route::get('achievement', fn() => Inertia::render('Achievement/Achievement'))->name('achievement');
 });


### PR DESCRIPTION
## プルリクエスト概要

このプルリクエストでは、**バリデーションエラー処理の変更**、**プロフィールページの更新**、および**ルートの変更**が含まれています。  
主な変更点として、バリデーションエラーのJSONレスポンスを廃止し、すべてのバリデーションエラーがリダイレクトされるように修正しました。また、プロフィールページのエラーメッセージを日本語化しました。

##  バリデーションエラー処理の更新

- `protected function failedValidation(Validator $validator)` において、JSONレスポンスの処理を削除し、すべてのバリデーションエラーを**リダイレクト**と**エラーメッセージの表示**に統一しました。  

## プロフィールページの更新

- `resources/js/Pages/Profile/Edit.jsx` を `resources/js/Pages/Profile/Profile.jsx` にリネーム  

## ルートの更新

- プロフィール編集ルートを新しいコンポーネントに更新
