### PR TITLE
change:認証回りの余分な処理整理

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -33,9 +33,8 @@ class LoginController extends Controller
 
             // 現在のユーザーのトークンを管理（既存のトークンを削除し、新しいトークンを作成）
             $user = Auth::user();
-            $this->deleteExistingToken($user); // 既存のトークンを削除
-            $token = $this->createUserToken($user); // 新しいトークンを作成
-
+            UserToken::deleteExistingToken($user); // 既存のトークンを削除
+            $token = UserToken::createUserToken($user); // 新しいトークンを作成
 
             // アプリ起動時に最初に表示されるカレンダー画面へ
             // ユーザー情報と認証トークンを渡して表示する
@@ -46,52 +45,5 @@ class LoginController extends Controller
         }
 
         return back()->withErrors(['login' => 'ユーザIDまたはパスワードが違います'])->withInput();
-    }
-
-    /**
-     * APIログイン処理
-     */
-    public function apiLogin(LoginRequest $request)
-    {
-        $user = User::where('login_id', $request->login_id)->first();
-
-        if (!$user || !Auth::attempt($request->only('login_id', 'password'))) {
-            return response()->json([
-                'message' => 'ユーザIDまたはパスワードが違います',
-                'code' => 'invalid_credentials'
-            ], 401);
-        }
-
-        // 既存のトークン削除
-        $this->deleteExistingToken($user);
-
-        // 新しいトークンを作成
-        $token = $this->createUserToken($user);
-
-        return response()->json([
-            'message' => 'ログイン成功',
-            'token' => $token->token,
-            'user' => $user
-        ], 200);
-    }
-
-    /**
-     * 既存のユーザートークンを削除
-     */
-    private function deleteExistingToken(User $user): void
-    {
-        if ($user->user_token) {
-            $user->user_token->delete();
-        }
-    }
-
-    /**
-     * 新しいユーザートークンを作成
-     */
-    private function createUserToken(User $user): UserToken
-    {
-        $token = new UserToken();
-        $token->createToken($user);
-        return $token;
     }
 }

--- a/app/Http/Controllers/Auth/LogoutController.php
+++ b/app/Http/Controllers/Auth/LogoutController.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Auth;
 class LogoutController extends Controller
 {
     /**
-     * Webログアウト処理
+     * ログアウト処理
      */
     public function logout(Request $request)
     {
@@ -20,20 +20,5 @@ class LogoutController extends Controller
         $request->session()->regenerateToken();
 
         return redirect('/login')->with('status', 'ログアウトしました。');
-    }
-
-    /**
-     * APIログアウト処理
-     */
-    public function apiLogout(Request $request)
-    {
-        $user = $request->user();
-
-        if ($user && $user->user_token) {
-            $user->user_token->delete();
-        }
-
-        Auth::guard('sanctum')->logout();
-        return response()->json(['message' => 'ログアウトしました。'], 200);
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -16,15 +16,7 @@ use Exception;
 class RegisterController extends Controller
 {
     /**
-     * 登録画面を表示
-     */
-    public function create()
-    {
-        return Inertia::render('Auth/RegisterForm');
-    }
-
-    /**
-     * Webの登録処理
+     * 登録処理
      */
     public function store(RegisterRequest $request)
     {
@@ -44,37 +36,6 @@ class RegisterController extends Controller
 
         return Inertia::render('Auth/RegisterForm', [
             'registrationSuccess' => true,
-        ]);
-    }
-
-    /**
-     * APIの登録処理
-     */
-    public function signup(RegisterRequest $request)
-    {
-        try {
-            $user = $this->createUser($request);
-
-            // 登録イベントを発生させる
-            event(new Registered($user));
-
-            return response()->json(['message' => '登録が完了しました', 'user' => $user], 201);
-        } catch (Exception $e) {
-            return response()->json(['error' => '登録中にエラーが発生しました'], 500);
-        }
-    }
-
-    /**
-     * 新しいユーザーを作成
-     */
-    private function createUser(RegisterRequest $request): User
-    {
-        return User::create([
-            'login_id' => $request->login_id,
-            'nickname' => $request->nickname,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
-            'birthday' => $request->birthday,
         ]);
     }
 }

--- a/app/Models/UserToken.php
+++ b/app/Models/UserToken.php
@@ -73,4 +73,18 @@ class UserToken extends Model
     {
         return Carbon::parse($value)->format('Y/m/d H:i');
     }
+
+    public static function deleteExistingToken(User $user): void
+    {
+        if ($user->user_token) {
+            $user->user_token->delete();
+        }
+    }
+
+    public static function createUserToken(User $user): UserToken
+    {
+        $token = new UserToken();
+        $token->createToken($user);
+        return $token;
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,11 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Auth\LoginController;
-use App\Http\Controllers\Auth\LogoutController;
-use App\Http\Controllers\Auth\RegisterController;
-use App\Http\Controllers\Auth\PasswordResetController;
-use App\Http\Controllers\Profile\ProfileController;
 use App\Http\Controllers\Calendar\EventController;
 use App\Http\Controllers\Calendar\TagController;
 use App\Http\Controllers\Calendar\WeekdayEventsController;
@@ -15,21 +10,8 @@ use App\Http\Controllers\Calendar\MonthlyEventsController;
 use App\Http\Controllers\Calendar\YearlyEventsController;
 use App\Http\Controllers\Achievement\AchievementController; 
 
-Route::prefix('v2/auth')->middleware('guest')->group(function () {
-    Route::post('register', [RegisterController::class, 'signup']);
-    Route::post('login', [LoginController::class, 'login']);
-    Route::post('forgot-password', [PasswordResetController::class, 'sendPasswordResetLink']);
-    Route::post('reset-password', [PasswordResetController::class, 'resetPassword']);
-});
 
 Route::prefix('v2')->group(function () {
-    Route::post('logout', [LogoutController::class, 'logout']);
-
-    //プロフィール API
-    Route::controller(ProfileController::class)->prefix('profile')->group(function () {
-        Route::get('/', 'show'); 
-    });
-
     //カレンダーイベント API
     Route::controller(EventController::class)->prefix('calendar/events')->group(function () {
         Route::get('/', 'index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,36 +8,33 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\PasswordResetController;
 use App\Http\Controllers\Profile\ProfileController;
 
-// 誰でもアクセス可能なルート（ログイン・登録・パスワードリセット）
-Route::get('login', [LoginController::class, 'create'])->name('login');
-Route::post('login', [LoginController::class, 'login']);
+// 誰でもアクセス可能なルート
+Route::get('/login', fn() => Inertia::render('Auth/LoginForm'))->name('login');
+Route::post('/login', [LoginController::class, 'login']);
 
-Route::get('register', [RegisterController::class, 'create'])->name('register');
-Route::post('register', [RegisterController::class, 'store']);
+Route::get('/register', fn() => Inertia::render('Auth/RegisterForm'))->name('register');
+Route::post('/register', [RegisterController::class, 'store']);
 
-Route::get('forgot-password', fn() => Inertia::render('Auth/ForgotPasswordForm'))->name('password.request');
-Route::post('forgot-password', [PasswordResetController::class, 'sendPasswordResetLink'])->name('password.email');
+Route::get('/forgot-password', fn() => Inertia::render('Auth/ForgotPasswordForm'))->name('password.request');
+Route::post('/forgot-password', [PasswordResetController::class, 'sendPasswordResetLink'])->name('password.email');
 
-Route::get('reset-password/{token}', fn($token) => Inertia::render('Auth/ResetPasswordForm', ['token' => $token]))->name('password.reset');
-Route::post('reset-password', [PasswordResetController::class, 'resetPassword'])->name('password.update');
+Route::get('/reset-password/{token}', fn($token) => Inertia::render('Auth/ResetPasswordForm', ['token' => $token]))->name('password.reset');
+Route::post('/reset-password', [PasswordResetController::class, 'resetPassword'])->name('password.update');
 
-// 認証済みユーザー専用ルート（プロフィール・ログアウト）
+// 認証済みユーザー専用ルート
 Route::middleware('auth')->prefix('user')->group(function () {
-    Route::post('logout', [LogoutController::class, 'logout'])->name('logout');
+    Route::post('/logout', [LogoutController::class, 'logout'])->name('logout');
 
     Route::controller(ProfileController::class)->prefix('profile')->group(function () {
-        Route::get('/edit', fn() => Inertia::render('Profile/Profile'))->name('profile.edit'); // 修正
+        Route::get('/edit', fn() => Inertia::render('Profile/Profile'))->name('profile.edit');
         Route::put('/', 'update')->name('profile.update');
         Route::put('/password', 'password')->name('profile.password');
         Route::delete('/', 'destroy')->name('profile.destroy');
     });
 
-    // カレンダールート（認証済みユーザーのみ）
     Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/calendar', fn() => Inertia::render('Calendar/Calendar'))->name('calendar');
+        Route::get('/weather', fn() => Inertia::render('Weather/Weather'))->name('weather');
+        Route::get('/achievement', fn() => Inertia::render('Achievement/Achievement'))->name('achievement');
     });
-
-    // Web UI 向けルート
-    Route::get('weather', fn() => Inertia::render('Weather/Weather'))->name('weather');
-    Route::get('achievement', fn() => Inertia::render('Achievement/Achievement'))->name('achievement');
 });


### PR DESCRIPTION
## **概要**
このプルリクエストでは、認証・登録プロセスの大幅なリファクタリングを行い、API専用のルートやメソッドの削除を実施しました。
主な変更点として、トークン管理を `UserToken` モデルに統合、ルートの整理を行いました。

## **変更点**

### **リファクタリングと簡素化**
- **`LoginController.php`**
  - `UserToken` モデルに `deleteExistingToken` および `createUserToken` の静的メソッドを追加し、トークン管理を統合。
  - `apiLogin` メソッドを削除。
  - `deleteExistingToken` と `createUserToken` のプライベートメソッドを削除。

- **`LogoutController.php`**
  - `apiLogout` メソッドを削除。

- **`RegisterController.php`**
  - `store` メソッドを簡素化。
  - `signup` メソッドと `createUser` のプライベートメソッドを削除。

### **トークン管理の統合**
- **`UserToken.php`**
  - `deleteExistingToken` と `createUserToken` の静的メソッドを追加し、トークン管理を統一。

### **ルートの整理**
- **`routes/api.php`**
  - 認証および登録に関するAPI専用ルートを削除。

- **`routes/web.php`**
  - ウェブルートを整理し、不要なコメントを削除。

この変更により、認証処理が一貫性のある形に統合され、メンテナンスしやすくなりました。
